### PR TITLE
Add dotenv-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,5 +45,7 @@ group :development, :test do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-end
 
+  # Keep environment variables (such as API keys) private
+  gem 'dotenv-rails'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,9 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    dotenv (2.0.1)
+    dotenv-rails (2.0.1)
+      dotenv (= 2.0.1)
     erubis (2.7.0)
     execjs (2.4.0)
     globalid (0.3.3)
@@ -168,6 +171,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
   devise (= 3.4.0)
+  dotenv-rails
   jbuilder (~> 2.0)
   jquery-rails
   rails (= 4.2.0)


### PR DESCRIPTION
This adds [dotenv](https://github.com/bkeepers/dotenv) in order to store environment variables in an `.env` file, so that private API keys are not accessible on GitHub.
